### PR TITLE
Cleanup Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
-require 'json'
-require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
-
-gem 'github-pages', versions['github-pages']
+gem 'github-pages'


### PR DESCRIPTION
GitHub pages always uses the latest version of the `github-pages` gem, that's the point of publishing that :gem:.

There is no need to keep asking them which version they are using.
