### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/sfbrigade/sfbrigade.github.io.png?label=ready&title=Ready)](https://waffle.io/sfbrigade/sfbrigade.github.io)
 # CodeForSanFrancisco.org
 
 The website for the Code for San Francisco Brigade


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/sfbrigade/sfbrigade.github.io

This was requested by a real person (user jasonlally) on waffle.io, we're not trying to spam you.
