### PR TITLE
Removing Hack Night Core Team

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -48,10 +48,6 @@ title: Code for San Francisco | About
       <li>Jacob Sills (@jsills on Slack)</li>
       <li>Katherine Nammacher (@kbnammacher on Slack)</li>
     </ul>
-    <h3>Hack Night</h3>
-    <ul>
-      <li>Michael Guia, <b>Team Lead</b> (@doublemochaa on Slack)</li>
-    </ul>
     <h3>Website &amp; Tools</h3>
     <ul>
       <li>Trent Oswald, <b>Team Lead</b> (@therebelrobot on Slack)</li>


### PR DESCRIPTION
As there is currently no core team member for Hack Night, I'm removing this section for the time being.
