### PR TITLE
Core Team additions/removals

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -51,7 +51,7 @@ title: Code for San Francisco | About
       <li>Trent Oswald, <b>Team Lead</b> (@therebelrobot on Slack)</li>
       <li>Jesse Szwedko (@jszwedko on Slack)</li>
     </ul>
-    <p>Interested in joining the leadership team? That’s great! Check out leadership roles here and reach out to Jesse or Maddie for more information.</p>
+    <p>Interested in joining the leadership team? That’s great! Check out leadership roles here and reach out to Hy for more information.</p>
 
     <h2>Our Partners</h2>
     <p>Code for San Francisco partners with San Francisco government and Bay Area non-profits to make our city work better. Here’s who we work with:</p>

--- a/about/index.html
+++ b/about/index.html
@@ -31,8 +31,7 @@ title: Code for San Francisco | About
     <p>Code for San Francisco is organized by a volunteer group of leaders. Reach us at hello@codeforsanfrancisco.org, or <a href="http://c4a.me/cfsfslack">join us on Slack</a></p>
     <h3>Executive Team</h3>
     <ul>
-      <li>Jesse Biroscak, <b>Co-Captain</b> (@jesse on Slack)</li>
-      <li>Maddie Suda, <b>Co-Captain</b> (@maddie on Slack)</li>
+      <li>Hy Carrel, <b>Interim Captain</b> (@hy on Slack)</li>
       <li>Vedrana Trbusic, <b>Public Relations</b> (@vedrana on Slack)</li>
     </ul>
     <h3>Member Support</h3>
@@ -46,14 +45,11 @@ title: Code for San Francisco | About
       <li>Larry Bafundo, <b>Team Lead</b> (@larry on Slack)</li>
       <li>Judy van Soldt (@judy on Slack)</li>
       <li>Jacob Sills (@jsills on Slack)</li>
-      <li>Katherine Nammacher (@kbnammacher on Slack)</li>
     </ul>
     <h3>Website &amp; Tools</h3>
     <ul>
       <li>Trent Oswald, <b>Team Lead</b> (@therebelrobot on Slack)</li>
       <li>Jesse Szwedko (@jszwedko on Slack)</li>
-      <li>Ryan Wold (@ryan on Slack)</li>
-      <li>Mari Hsu (@mhsu on Slack)</li>
     </ul>
     <p>Interested in joining the leadership team? That’s great! Check out leadership roles here and reach out to Jesse or Maddie for more information.</p>
 


### PR DESCRIPTION
Added @hcarrinski to the Executive Team, removed @hackajesse and @sfmaddie while they're on leave

Removed Katherine from Projects team per her request

Removed @bouncinglime and @afomi from Website and Tools, as they've stepped back from core by this point.
