### PR TITLE
Add temporary button for CodeAcross event

### DIFF
--- a/_includes/css/sfbrigade.css
+++ b/_includes/css/sfbrigade.css
@@ -143,8 +143,12 @@ table h3 {
 }
 
 .jumbotron {
-  margin-top: 50px;
+  margin-top: 20px;
   background: rgba(0,0,0,0.44)
+}
+
+.jumbotron .row {
+  margin-top: 10px;
 }
 
 
@@ -470,6 +474,11 @@ transition: background 0.2s,border 0.2s;
 
 .btn-hack {
   background-color: #0a83c5;
+  color: #fff;
+}
+
+.btn-special-event {
+  background-color: #E2768D;
   color: #fff;
 }
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -91,7 +91,12 @@
                     We meet every week to hack for change. Join us, everyone is welcome!
                   </p>
                   </div>
-                  <a class="btn btn-lg btn-hack" href="http://www.meetup.com/Code-for-San-Francisco-Civic-Hack-Night/">Join us for an upcoming Weekly Civic Hack Night!</a>
+                  <div class="row">
+                    <a class="btn btn-lg btn-special-event" href="http://www.meetup.com/Code-for-San-Francisco-Civic-Hack-Night/events/228463981/">Join us for CodeAcross!</a>
+                  </div>
+                  <div class="row">
+                    <a class="btn btn-lg btn-hack" href="http://www.meetup.com/Code-for-San-Francisco-Civic-Hack-Night/">Join us for an upcoming Weekly Civic Hack Night!</a>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Add a button to the jumbotron to link to the codeacross meetup event

Fixes #150 

Looks like 
![2016-02-13-144101_1265x450_scrot](https://cloud.githubusercontent.com/assets/316880/13030431/e4313a82-d25f-11e5-8693-e9ccae82f13d.png)
