### PR TITLE
Add a Google calendar to the events page

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -4,7 +4,8 @@ title: Events
 lead: Happenings You Might Want to Check Out
 ---
 <div id="events" style="margin-top:20px">
-<div class="col-md-4 sidebar">
+<div class="col-md-8 sidebar">
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=g2hqev0vr05tg5uc7s8qmjha4s%40group.calendar.google.com&amp;color=%23711616&amp;src=1fcu54gntj5vhrkoj7kmk8gddj8s2g5t%40import.calendar.google.com&amp;color=%2328754E&amp;ctz=America%2FLos_Angeles" style="border-width:0" width="600" height="600" frameborder="0" scrolling="no"></iframe>
   <h2>Weekly Hack Nights<h2>
 
   <h4>Logistics</h4>
@@ -21,10 +22,10 @@ lead: Happenings You Might Want to Check Out
   <p>
   <a href="http://codeforsanfrancisco.org/signup" class="btn btn-xs btn-success btn-strong-alone">Get Our Newsletter</a>
   </p>
-
 </div>
 
-<div class="col-md-8">
+<div class="col-md-4">
+<h1>Featured</h1>
 <div>
     <h2>Code Across</h2>
     <h4>March 5 2016</h4>


### PR DESCRIPTION
So that users to quickly glance at upcoming events or add the calendar
to their own.

Here we flip the column orientation to make space for the calendar on
the left so that we can keep featured events towards the top of the
page, in the right column.

Addresses #118
