### PR TITLE
Remove icanhaz.js and fix templates

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -36,7 +36,7 @@
   });
 </script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/ICanHaz.js/0.10.3/ICanHaz.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/mustache.js/2.2.1/mustache.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.2/moment.min.js"></script>
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -8,8 +8,7 @@
       <h2 class="first needs">Needs</h2>
       <button type="button" class="btn btn-success btn-block" data-toggle="modal" data-target="#exampleModal">I want to Help!</button>
     </div>
-
-    <h2 class="code">Code</h2> {% include updates.html %}
+<h2 class="code">Details</h2> {% include updates.html %}
   </div>
 </div>
 {% include footer.html%}
@@ -108,29 +107,29 @@
   </div>
 </div>
 
-<script id="needsList" type="text/html">
+<script id="needsList" type="x-tmpl-mustache">
   {% raw %}
   {{#needs}}
     <a href="{{html_url}}" class="list-group-item">{{title}}</a>
   {{/needs}}
   {% endraw %}
 </script>
-<script id="repoPanels" type="text/html">
+<script id="repoPanels" type="x-tmpl-mustache">
   {% raw %}
   {{#repos}}
-
     <div class="panel panel-default">
-      {{#github_details}}
       <div class="panel-heading">
-        <a href="{{code_url}}">{{#github_details}}<h3 class="panel-title">/{{name}}</h3></a>
+        <a href="{{link_url}}"><h3 class="panel-title">{{name}}</h3></a>
       </div>
       <div class="panel-body">
         <p>{{description}}</p>
       </div>
-      {{/github_details}}
       <div class="list-group">
-        <a href="{{code_url}}/issues" class="list-group-item">Issues<span class="badge">{{issue_count}}</span></a>
-        <a href="{{code_url}}/contributors" class="list-group-item">Contributors<span class="badge">{{contributor_count}}</span></a>
+        <a href="{{code_url}}" class="list-group-item">Code</a>
+        {{#github_details}}
+          <a href="{{code_url}}/issues" class="list-group-item">Issues<span class="badge">{{open_issues}}</span></a>
+          <a href="{{code_url}}/contributors" class="list-group-item">Contributors<span class="badge">{{contributors.length}}</span></a>
+        {{/github_details}}
       </div>
     </div>
   {{/repos}}
@@ -149,44 +148,11 @@ $.getJSON(cfapi_project, showProjectDetails);
 
 function showProjectDetails(response) {
   // Fill up the projects list
-  console.log(response);
-  repos = response;
-  repos.issue_count = response.issues.length;
-
-  repos.contributor_count = 0;
-  if (response.github_details) {
-    repos.contributor_count = response.github_details.contributors.length;
-  }
-
-  var repoPanels = ich.repoPanels({
-    repos: repos
+  var template = $('#repoPanels').html();
+  var repoPanels = Mustache.render(template, {
+    repos: response
   });
   $("h2.code").after(repoPanels);
-
-  // Follow next page links
-  /*if (data.pages.next) {
-    $.when($.getJSON(data.pages.next)).then(showProjects);
-  } else {
-    $.each(projects, function(i,json){
-      if(github_url.indexOf(json.code_url) > -1) {
-        json.issue_count = json.issues.length;
-        json.contributor_count = json.github_details.contributors.length;
-        issues = issues.concat(json.issues);
-        repos = repos.concat(json);
-      }
-    });
-    $.each(issues, function(i,json){
-      $.each(json.labels, function(j,label){
-        if(label.name == 'project-needs') {
-          needs = needs.concat(json);
-        }
-      });
-    });
-    var needsList = ich.needsList({needs: needs});
-    var repoPanels = ich.repoPanels({repos: repos});
-    $("h2.needs").after(needsList);
-    $("h2.code").after(repoPanels);
-  }*/
 }
 </script>
 </body>

--- a/js/projects.js
+++ b/js/projects.js
@@ -33,10 +33,12 @@ function showProjects(response){
 
   });
 
+  var template = $('#projects').html();
+
   var featuredDiv = document.createElement('div');
   featuredDiv.id = 'featured';
   $("#hack-night-projects").append(featuredDiv);
-  $("#hack-night-projects").append(ich.projects({projects:projects}));
+  $("#hack-night-projects").append(Mustache.render(template, { projects: projects }));
   // Follow next page links
   if (response.pages.next) {
     $.getJSON(response.pages.next, showProjects);

--- a/projects/index.html
+++ b/projects/index.html
@@ -11,7 +11,7 @@ lead: 'The fine works of Code for San Francisco'
 </section>
 
 <!-- Define the template for data loaded from the CFAPI -->
-<script id="projects" type="text/html">
+<script id="projects" type="x-tmpl-mustache">
 {%raw%}
 {{#projects}}
 
@@ -20,7 +20,7 @@ lead: 'The fine works of Code for San Francisco'
       <h1>{{name}} {{^cfsf_url}}
           <a href="https://github.com/login/oauth/authorize?client_id=c602a8bd54b1e774f864&scope=repo&redirect_uri=http://prose.io/#{{repository_nwo}}/new/{{default_branch}}/_posts/projects/{{id}}/{{file_name}}" class="btn btn-xs btn-success">Create detailed project page</a></strong><span style="display:none">{{id}}</span>
           {{/cfsf_url}}</h1>
-      <p class="lead">{{description}} 
+      <p class="lead">{{description}}
       {{#cfsf_url}}
       <strong><a href="{{cfsf_url}}">Learn more...</a></strong>
       {{/cfsf_url}}</p>


### PR DESCRIPTION
The templates on the project pages are currently failing to render --
this fixes this as well as swaps ICanHaz.js with mustache.js (which
ICanHaz.js used under the hood) because ICanHaz.js is no longer actively
supported and was using a very old version of mustache.js.
